### PR TITLE
Add cache-control to responses

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,8 @@ http {
     listen <%= ENV["PORT"] %>;
     set $target_domain <%= ENV["TARGET_DOMAIN"] %>;
     server_name localhost;
+
+    expires 3600;
     return 301 $scheme://$target_domain$request_uri;
   }
 }


### PR DESCRIPTION
Prevents default behavior in some browsers to cache indefinitely.

cc @yozlet