### PR TITLE
Use 302 instead of 301

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Small app to redirect traffic from one domain to another.
 
+
 ## Usage
 
 In `manifest.yml`, change `TARGET_DOMAIN` to the domain you want to redirect _to_. Change `host` to the hostname you want to redirect _from_.
@@ -34,3 +35,21 @@ env:
 Now you can deploy like so.
 
     $ cf push -f redirects/redirect-from-domain.apps.cloud.gov/manifest.yml
+
+
+## A note on permanence
+
+The redirect uses a temporary 302 redirect. In some cases you might want to use
+a [permanent
+redirect](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2),
+for example, when the application has been permanently assigned a new URI. Note
+that without any caching directive, browsers may cache this response indefinitely
+which makes it very difficult to re-use the old URI for anything else. If you
+choose to use the 301 redirect, we suggest you include cache control to prevent
+the 301 being cached indefinitely.
+
+```
+# in nginx.conf
+expires 3600;
+return 301 $scheme://$target_domain$request_uri;
+```

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,8 @@ http {
     listen <%= ENV["PORT"] %>;
     set $target_domain <%= ENV["TARGET_DOMAIN"] %>;
     server_name localhost;
-    return 301 $scheme://$target_domain$request_uri;
+
+    expires 3600;
+    return 302 $scheme://$target_domain$request_uri;
   }
 }


### PR DESCRIPTION
From [earlier discussion](https://github.com/18F/cf-redirect/pull/2) we should opt for a temporary 302 redirect rather than a permanent one to avoid browsers caching indefinitely.