### PR TITLE
Redirect scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,18 @@ the 301 being cached indefinitely.
 expires 3600;
 return 301 $scheme://$target_domain$request_uri;
 ```
+
+## Use cases
+
+### Serve a notice
+
+Maybe there are a few files you want to serve, rather than redirect. Just
+include them in your directory. The nginx config will look for html files first,
+then fallback to the redirect. This can be used to serve an index.html that
+might have a notice about the redirect. You can use a meta-refresh to redirect
+the user after a few seconds.
+
+Include this line in your index.html `<head>` to redirect the user after 10
+seconds.
+
+    <meta http-equiv="refresh" content="10;url=https://your-target-domain.example.com">

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ expires 3600;
 return 301 $scheme://$target_domain$request_uri;
 ```
 
+
 ## Use cases
+
 
 ### Serve a notice
 
@@ -56,3 +58,17 @@ Include this line in your index.html `<head>` to redirect the user after 10
 seconds.
 
     <meta http-equiv="refresh" content="10;url=https://your-target-domain.example.com">
+
+
+### Redirect to homepage
+
+By default, the nginx config includes the URI path in the redirect. If the URLs
+on your old site don't match the new site, the redirect will end up with a 404.
+If you'd rather redirect to the homepage, you can remove the `$request_uri` from
+the `return` line.
+
+      return 302 $redirect_scheme://$target_domain$request_uri;
+
+Changes to:
+
+      return 302 $redirect_scheme://$target_domain;

--- a/README.md
+++ b/README.md
@@ -20,18 +20,6 @@ these files to a `redirects/<redirect-from-domain>` dir in the app you're
 redirecting _to_. This way all the redirects to your app are stored in a single
 repo.
 
-Then you can add a `path` property to the manifest file to make deployments easy.
-
-```
----
-memory: 64MB
-name: cf-redirect
-host: redirect-from-domain
-path: ./redirects/redirect-from-domain.apps.cloud.gov
-env:
-  TARGET_DOMAIN: redirect-to-domain.apps.cloud.gov
-```
-
 Now you can deploy like so.
 
     $ cf push -f redirects/redirect-from-domain.apps.cloud.gov/manifest.yml

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,5 +3,6 @@ buildpack: staticfile_buildpack
 memory: 64MB
 name: cf-redirect
 host: redirect-from-domain
+path: .
 env:
   TARGET_DOMAIN: redirect-to-domain.apps.cloud.gov

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,6 +19,7 @@ http {
     location / {
       root <%= ENV["APP_ROOT"] %>/public;
       index index.html;
+      try_files $uri $uri/index.html @redirect;
     }
 
     location @redirect {

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,8 +14,16 @@ http {
     listen <%= ENV["PORT"] %>;
     set $target_domain <%= ENV["TARGET_DOMAIN"] %>;
     server_name localhost;
+    error_page 404 = @redirect;
 
-    expires 3600;
-    return 302 $redirect_scheme://$target_domain$request_uri;
+    location / {
+      root <%= ENV["APP_ROOT"] %>/public;
+      index index.html;
+    }
+
+    location @redirect {
+      expires 3600;
+      return 302 $redirect_scheme://$target_domain$request_uri;
+    }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,12 +5,17 @@ error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
 events { worker_connections 1024; }
 
 http {
+  map $http_x_forwarded_proto $redirect_scheme {
+    default $scheme;
+    https https;
+  }
+
   server {
     listen <%= ENV["PORT"] %>;
     set $target_domain <%= ENV["TARGET_DOMAIN"] %>;
     server_name localhost;
 
     expires 3600;
-    return 302 $scheme://$target_domain$request_uri;
+    return 302 $redirect_scheme://$target_domain$request_uri;
   }
 }


### PR DESCRIPTION
Fixes #5.

Some additional improvements to how the redirect works:
- Include `path: .` in manifest which works better in general
- Serve any html files, then fallback to a redirect
- Add a note about redirecting to root of a domain (by default we include the path in the redirect)